### PR TITLE
Remove references to help-pages.css

### DIFF
--- a/_layouts/default-guide.html
+++ b/_layouts/default-guide.html
@@ -14,7 +14,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/default-lpa-2.html
+++ b/_layouts/default-lpa-2.html
@@ -13,7 +13,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/default-lpa.html
+++ b/_layouts/default-lpa.html
@@ -15,7 +15,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/default-programme.html
+++ b/_layouts/default-programme.html
@@ -14,7 +14,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/default-smartanswer.html
+++ b/_layouts/default-smartanswer.html
@@ -14,7 +14,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/default-transaction.html
+++ b/_layouts/default-transaction.html
@@ -14,7 +14,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/default-wrapper.html
+++ b/_layouts/default-wrapper.html
@@ -14,7 +14,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">

--- a/_layouts/finance-finder.html
+++ b/_layouts/finance-finder.html
@@ -14,7 +14,6 @@
     <link href="http://static.preview.alphagov.co.uk/static/search.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/homepage.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/error-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
-    <link href="http://static.preview.alphagov.co.uk/static/static-pages/help-pages.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/static-pages/tour.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/publisher.css?body=1" media="screen" rel="stylesheet" type="text/css">
     <link href="http://static.preview.alphagov.co.uk/static/multi-step.css?body=1" media="screen" rel="stylesheet" type="text/css">


### PR DESCRIPTION
The alphagov/prototyping#3 pull request removed help-pages.css as it was
empty. This is to remove all link tags that reference it.
